### PR TITLE
Update queries.ts

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -216,8 +216,17 @@ export class QueriesClient extends Client {
         reject(new Error('queries subscription requires a callback'));
         return;
       }
+      
+      let isClosed = false;
       let unsubscribe = false;
       const onStateChange = new TypedEvent<string>();
+      onStateChange.on((event)=>{
+        if (event==='close'){
+          isClosed = true;
+          onStateChange.emit('disconnected');
+        }
+      });
+
       resolve({
         onState: onStateChange,
         unsubscribe() {
@@ -228,13 +237,9 @@ export class QueriesClient extends Client {
       while (!unsubscribe) {
         onStateChange.emit('connecting');
         await this.subscribeFn(request, cb).then((value) => {
-          value.onClose.on(() => {
-            isClosed = true;
-            onStateChange.emit('disconnected');
-          });
           currentStream = value.stream;
         });
-        let isClosed = false;
+        isClosed = false;
         onStateChange.emit('connected');
         while (!isClosed && !unsubscribe) {
           await new Promise((r) => setTimeout(r, 1000));


### PR DESCRIPTION
Fixing a problem to handle reconnection.
In this way on error client of this library can decide to request a close to make a reconnection emitting an event on onStateChange.
This is not the optimal solution but it is a reasonable way to solve the issue with a minimum change.