### PR TITLE
Fixed RPC subscribe reconnection and incorrect closing handling.

### DIFF
--- a/examples/rpc/queries/subscribe.ts
+++ b/examples/rpc/queries/subscribe.ts
@@ -1,0 +1,63 @@
+import { Config, Utils, QueriesClient } from '../../../src';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const opts: Config = {
+  address: 'localhost:50000',
+  clientId: Utils.uuid(),
+  reconnectInterval: 5000,
+};
+const queriesClient = new QueriesClient(opts);
+
+const testSubscribe = async () => {
+  const serverClientId = Utils.uuid();
+  const subscription = await queriesClient.subscribe(
+    {
+      channel: 'test.prpc.subscribe',
+      clientId: serverClientId,
+    },
+    (err, msg) => {
+      if (err) {
+        console.log('Subscription error event:', err);
+      } else {
+        console.log('Subscription message event:', msg);
+        return queriesClient.response({
+          clientId: serverClientId,
+          error: '',
+          executed: true,
+          id: msg.id,
+          replyChannel: msg.replyChannel,
+          timestamp: Date.now(),
+          body: 'Hello from server',
+        });
+      }
+    },
+  );
+
+  console.log('Subscription initialized');
+
+  // Handle subscription state changes
+  subscription.onState.on((event) => {
+    console.log("Received '%s' event", event);
+    if (event === 'disconnected') {
+      console.log('Unsubscribed from channel');
+    }
+  });
+
+  // Send a message to the channel
+  await sleep(1000);
+  await queriesClient
+    .send({
+      channel: 'test.prpc.subscribe',
+      clientId: Utils.uuid(),
+      body: 'Hello from client',
+    })
+    .catch((error) => console.error('Error sending message:', error));
+
+  // Wait for 10 seconds before unsubscribing
+  await sleep(10_000);
+  console.log('Unsubscribing from channel');
+  subscription.unsubscribe();
+};
+
+testSubscribe();


### PR DESCRIPTION
This PR fixes #1. 

Previously, the `subscribe` method of the `QueriesClient` class had incorrect handling of close and unsubscribe events. The event received from `stream.on("close")` did not lead to any consequences. If the connection to KubeMQ was lost, then reconnection could not occur, because `isClosed` was always `false`.

I also moved the subscription from cycle-dependent to event mode, so as not to once again load the event loop with unnecessary functions deferred every second.

Here is a bug, `onClose` was not called on the other side: https://github.com/kubemq-io/kubemq-js/blob/main/src/queries.ts#L296C1-L304C12
```typescript
let onClose = new TypedEvent<void>();
stream.on('close', () => {
  onClose.emit();
});
resolve({
  onClose: onClose,
  stream: stream,
});
``` 